### PR TITLE
Avoid zero time step in main loop

### DIFF
--- a/game.py
+++ b/game.py
@@ -61,7 +61,8 @@ class Player:
         self.mouse_body.position = pos
         self.prev_mouse_pos = pos
         # Anchor the drag joint at the clicked position on the square
-        local_anchor = (Vec2d(pos) - self.body.position).rotated(-self.body.angle)
+        # `pos` is already a Vec2d, so avoid reinitializing to prevent errors
+        local_anchor = (pos - self.body.position).rotated(-self.body.angle)
         self.drag_joint = pymunk.PivotJoint(self.mouse_body, self.body,
                                             (0, 0), local_anchor)
         self.drag_joint.max_force = 10000
@@ -137,6 +138,8 @@ def main():
     running = True
     while running:
         dt = clock.tick(60) / 1000.0
+        if dt <= 0:
+            dt = 1e-6
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False


### PR DESCRIPTION
## Summary
- prevent division by zero in game update loop
- fix Vec2d reinitialization bug when dragging

## Testing
- `python -m py_compile game.py`
